### PR TITLE
Use verifier agent and config for verifier tests

### DIFF
--- a/load-agent/locustMediatorPresentProof.py
+++ b/load-agent/locustMediatorPresentProof.py
@@ -43,7 +43,7 @@ class UserBehaviour(SequentialTaskSet):
 
     @task
     def get_verifier_invite(self):
-        verifier_invite = self.client.issuer_getinvite()
+        verifier_invite = self.client.verifier_getinvite()
         self.verifier_invite = verifier_invite
 
     @task

--- a/load-agent/locustMediatorPresentProofExisting.py
+++ b/load-agent/locustMediatorPresentProofExisting.py
@@ -41,7 +41,7 @@ class UserBehaviour(SequentialTaskSet):
         credential = self.client.receive_credential(self.invite["connection_id"])
 
     def get_verifier_invite(self):
-        verifier_invite = self.client.issuer_getinvite()
+        verifier_invite = self.client.verifier_getinvite()
         self.verifier_invite = verifier_invite
 
     def accept_verifier_invite(self):

--- a/load-agent/verifierAgent/acapy.py
+++ b/load-agent/verifierAgent/acapy.py
@@ -11,14 +11,14 @@ VERIFIED_TIMEOUT_SECONDS = int(os.getenv("VERIFIED_TIMEOUT_SECONDS", 20))
 class AcapyVerifier(BaseVerifier):
 
         def get_invite(self, out_of_band=False):
-                headers = json.loads(os.getenv("ISSUER_HEADERS"))
+                headers = json.loads(os.getenv("VERIFIER_HEADERS"))
                 headers["Content-Type"] = "application/json"
 
                 if out_of_band:
                         # Out of Band Connection 
                         # (ACA-Py v10.4 - only works with connections protocol, not DIDExchange) 
                         r = requests.post(
-                                os.getenv("ISSUER_URL") + "/out-of-band/create-invitation?auto_accept=true", 
+                                os.getenv("VERIFIER_URL") + "/out-of-band/create-invitation?auto_accept=true", 
                                 json={
                                 "metadata": {}, 
                                 "handshake_protocols": ["https://didcomm.org/connections/1.0"]
@@ -28,7 +28,7 @@ class AcapyVerifier(BaseVerifier):
                 else:
                         # Regular Connection
                         r = requests.post(
-                                os.getenv("ISSUER_URL") + "/connections/create-invitation?auto_accept=true",
+                                os.getenv("VERIFIER_URL") + "/connections/create-invitation?auto_accept=true",
                                 json={"metadata": {}, "my_label": "Test"},
                                 headers=headers,
                         )
@@ -47,7 +47,7 @@ class AcapyVerifier(BaseVerifier):
                 if out_of_band:
                         invitation_msg_id = r['invi_msg_id']
                         g = requests.get(
-                                os.getenv("ISSUER_URL") + "/connections",
+                                os.getenv("VERIFIER_URL") + "/connections",
                                 params={"invitation_msg_id": invitation_msg_id},
                                 headers=headers,
                         )
@@ -130,7 +130,7 @@ class AcapyVerifier(BaseVerifier):
                 try:
                         while iteration < VERIFIED_TIMEOUT_SECONDS:
                                 g = requests.get(
-                                        os.getenv("ISSUER_URL") + f"/present-proof/records/{presentation_exchange_id}",
+                                        os.getenv("VERIFIER_URL") + f"/present-proof/records/{presentation_exchange_id}",
                                         headers=headers,
                                 )
                                 if (
@@ -155,7 +155,7 @@ class AcapyVerifier(BaseVerifier):
                 return True
 
         def send_message(self, connection_id, msg):
-                headers = json.loads(os.getenv("ISSUER_HEADERS"))
+                headers = json.loads(os.getenv("VERIFIER_HEADERS"))
                 headers["Content-Type"] = "application/json"
 
                 r = requests.post(


### PR DESCRIPTION
For the BCGov verification use cases we are using a Traction agent (just a multitenant ACA-Py really) for issuing and verifying as is done in the existing locustMediatorPresentProof test. (I'm creating my own test script that's not committed here but essentially same steps as `locustMediatorPresentProof.py`)

I'm seeing that 

1. The test invokes the issuer client to get the invite in the `get_verifier_invite` step
2. In the verifier agent web requests `load-agent/verifierAgent/acapy.py` it is using the ISSUER_* environment values instead of the VERIFIER_* ones.

I'm not sure if using a same issuer agent is the intent here? But it seems it should be using the configured verifier agent in this case instead (if that **is** to be the same agent as the issuer I think it could just be that the test operator sets the verifier config to the same url/headers as the issuer one).

I've confirmed our tests that we are developing running with the changes contained in this PR. 