### PR TITLE
Delete OOB utility function

### DIFF
--- a/load-agent/agent.ts
+++ b/load-agent/agent.ts
@@ -272,12 +272,7 @@ const pingMediator = async (agent) => {
 }
 
 let deleteOobRecordById = async (agent, id) => {
-  try {
-    const resp = await agent.oob.deleteById(id);
-    
-  } catch (error) {
-    process.stderr.write('ERROR'+ '\n' + error + '\n')
-  }
+  await agent.oob.deleteById(id);
 };
 
 let receiveInvitation = async (agent, invitationUrl) => {

--- a/load-agent/agent.ts
+++ b/load-agent/agent.ts
@@ -271,6 +271,15 @@ const pingMediator = async (agent) => {
   }
 }
 
+let deleteOobRecordById = async (agent, id) => {
+  try {
+    const resp = await agent.oob.deleteById(id);
+    
+  } catch (error) {
+    process.stderr.write('ERROR'+ '\n' + error + '\n')
+  }
+};
+
 let receiveInvitation = async (agent, invitationUrl) => {
   // wait for the connection
   let timeout = config.verified_timeout_seconds * 1000
@@ -577,6 +586,12 @@ rl.on('line', async (line) => {
       await pingMediator(agent)
       process.stdout.write(
         JSON.stringify({ error: 0, result: 'Ping Mediator' }) + '\n'
+      )
+    } else if (command['cmd'] == 'deleteOobRecordById') {
+      await deleteOobRecordById(agent, command['id'])
+
+      process.stdout.write(
+        JSON.stringify({ error: 0, result: 'Delete OOB Record' }) + '\n'
       )
     } else if (command['cmd'] == 'receiveInvitation') {
       let connection = await receiveInvitation(agent, command['invitationUrl'])

--- a/load-agent/locustClient.py
+++ b/load-agent/locustClient.py
@@ -267,6 +267,12 @@ class CustomClient:
         return self.issuer.is_up()
 
     @stopwatch
+    def delete_oob(self, id):
+        self.run_command({"cmd": "deleteOobRecordById", "id": id})
+
+        line = self.readjsonline()
+
+    @stopwatch
     def accept_invite(self, invite, useConnectionDid=False):
         try:
             if useConnectionDid:


### PR DESCRIPTION
For [one of the BC Gov IAS testing cases](https://github.com/bcgov/aries-load-generator/pull/7) we delete the OOB record so an agent can accept the same invitation again. In that I'd added a call for the AFJ agent to do this.

It's very bare bones compared to the other connection management calls, doesn't do a defer to wait for state changes, but that may(?) be appropriate for a simple delete record call the way this is invoking AFJ `oob.deleteById`

Would be good to pull this simple call in at least so the BCGov IAS tests don't need manual/forked Akrida changes to run, if more feature/additional complexity needed could iterate on it later.