### PR TITLE
Add a way to get connection and connection DID when accepting invite

### DIFF
--- a/load-agent/locustClient.py
+++ b/load-agent/locustClient.py
@@ -267,9 +267,12 @@ class CustomClient:
         return self.issuer.is_up()
 
     @stopwatch
-    def accept_invite(self, invite):
+    def accept_invite(self, invite, useConnectionDid=False):
         try:
-            self.run_command({"cmd": "receiveInvitation", "invitationUrl": invite})
+            if useConnectionDid:
+                self.run_command({"cmd": "receiveInvitationConnectionDid", "invitationUrl": invite})
+            else:
+                self.run_command({"cmd": "receiveInvitation", "invitationUrl": invite})
         except Exception:
             self.run_command({"cmd": "receiveInvitation", "invitationUrl": invite})
 


### PR DESCRIPTION
For the BCGov IAS load testing use cases we need the connection and connection-specific-DID for calling off to the IAS controller to do issuance. Rather than the outOfBandRecord that is currently returned.

The existing way of accepting an invite calls `receiveInvitation` in the `agent.ts` and that returns the outOfBandRecord from the call to Credo (`const { outOfBandRecord } = await agent.oob.receiveInvitationFromUrl(invitationUrl)`)

Added an alternate Receive Invitation method that gets the connection record and then uses `DidRepository` to get the legacy connection DID out of that connection (see comments in code).

Then when accepting an invite with the client, allow caller to specify a `useConnectionDid` param if they want this additional information.

This does add some code duplication with the defer/onConnection/etc part but I wanted to provide this alternate code path to not affect existing scripts (will use in BCGov ones) and exclude the legacy DID stuff. But probably could parameterize the _existing_ `receiveInvitation` method to have these options instead.
Looking for feedback and guidance if this way is ok or would rather modify the existing method instead.