### PR TITLE
fix: dockerfile for undefined volume mediator-db

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -152,3 +152,4 @@ networks:
 
 volumes:
   issuer-db:   
+  mediator-db:  


### PR DESCRIPTION
# What:
- Fixes ```service "mediator-db" refers to undefined volume mediator-db: invalid compose project``` when trying to follow the [QuickStart](https://github.com/GHkrishna/aries-akrida/blob/main/docs/QUICKSTART.md) and run the command ```docker-compose -f docker-compose.demo.yml up```