### PR TITLE
feat: Adjust heap limit to 128mb per agent

### DIFF
--- a/load-agent/locustClient.py
+++ b/load-agent/locustClient.py
@@ -134,7 +134,7 @@ class CustomClient:
 
             self.errors = 0
             self.agent = subprocess.Popen(
-                ["node", "--max-old-space-size=64", "dist/agent.js"],
+                ["node", "--max-old-space-size=128", "dist/agent.js"],
                 bufsize=0,
                 universal_newlines=True,
                 stdout=subprocess.PIPE,


### PR DESCRIPTION
The 64mb heap limit was too aggressive. Causes excessive cpu churn. 128mb seems like a better middle ground to not use too much memory but keep agent GC and cpu less stressed. 